### PR TITLE
Changed part of stack displayed on assertion failure

### DIFF
--- a/src/Tester.lua
+++ b/src/Tester.lua
@@ -30,7 +30,7 @@ function Tester:_failure (message)
     local name = self.curtestname
     self.assertionFail[name] = self.assertionFail[name] + 1
     local ss = debug.traceback('tester',2)
-    ss = ss:match('[.]*\n([^\n]+\n[^\n]+)\n[^\n]+xpcall')
+    ss = ss:match('.-\n([^\n]+\n[^\n]+)\n[^\n]+xpcall')
     if type(message) == 'function' then
         message = message()
     end


### PR DESCRIPTION
Outputs most relevant part of stack when test assertion fails: user function + line number, and first used (assertion) function within Tester (but no deeper helper functions such as _assert_sub) 
