### PR TITLE
Used a local var for origType

### DIFF
--- a/totem/nn.lua
+++ b/totem/nn.lua
@@ -294,7 +294,7 @@ the original type.
 --]]
 function totem.nn.checkTypeCastable(tester, module, input, toType)
     local precision = 1e-6
-    origType = inputType(input)
+    local origType = inputType(input)
     toType = toType or 'torch.FloatTensor'
     local rngState = torch.getRNGState()
     local preOutput = module:updateOutput(input)


### PR DESCRIPTION
Next time, you can find the bug yourself, by using `require 'util/warn'`
