### PR TITLE
This makes assertTensorEq work for ByteTensors

### DIFF
--- a/totem/Tester.lua
+++ b/totem/Tester.lua
@@ -167,7 +167,7 @@ function Tester:assertTensorEq(ta, tb, condition, message, neg)
         return
     end
 
-    local diff = ta:clone():add(-1, tb)
+    local diff = ta:clone():double():add(-1, tb:double())
     local err = diff:abs():max()
     local errMessage = string.format('%s\n%s  val=%s, condition=%s',
                                      message, ' TensorEQ(==) violation ',


### PR DESCRIPTION
torch.ByteTensor has no abs(). Converting to doubles gives correct behaviour for ByteTensors, but no longer does type checking on the two tensor arguments. Is the intended behaviour of assertTensorEq to check that the types match?

Shouldn't we have tests for the test library?
