### PR TITLE
Checked the gradInput sizes.

### DIFF
--- a/totem/Tester.lua
+++ b/totem/Tester.lua
@@ -357,7 +357,7 @@ function Tester:eq(got, expected, label, precision, ret)
     elseif type(expected) == "table" then
         return self:_eqTable(got, expected, label, precision)
     elseif type(expected) == "userdata" then
-        if torch.isTensor(got) then
+        if isTensor(got) then
             self:_eqSize(got, expected, label)
             diff = got:clone():add(-1, expected):abs():max()
             ok = diff <= precision


### PR DESCRIPTION
I updated the gradient checking to check that the gradInput size matches the input size.

I don't know how to call the CopyModule constructor, without defining totem._nn_CopyModule.
Tell me, if there is a better way.
