### PR TITLE
totem.assertTensorEq didn't perform an assert()

### DIFF
--- a/tests/test_totem.lua
+++ b/tests/test_totem.lua
@@ -123,4 +123,42 @@ function tests.test_assertErrorPattern()
   meta_assert_failure(subtester:assertErrorPattern(bad_fn, "hehe", MESSAGE))
 end
 
+function tests.test_totemTensorEqChecks()
+  local t1 = torch.randn(100,100)
+  local t2 = t1:clone()
+  local t3 = torch.randn(100,100)
+
+  local success, msg = totem.areTensorsEq(t1, t2, 1e-5)
+  tester:assert(success, "areTensorsEq should return true")
+  tester:asserteq(msg, nil, "areTensorsEq erroneously gives msg on success")
+
+  local success, msg = totem.areTensorsEq(t1, t3, 1e-5)
+  tester:assert(not success, "areTensorsEq should return false")
+  tester:asserteq(type(msg), 'string', "areTensorsEq should return a message")
+
+  tester:assertNoError(function() totem.assertTensorEq(t1, t2, 1e-5) end,
+                       "assertTensorEq not raising an error")
+  tester:assertError(function() totem.assertTensorEq(t1, t3, 1e-5) end,
+                     "assertTensorEq not raising an error")
+end
+
+function tests.test_totemTensorNeChecks()
+  local t1 = torch.randn(100,100)
+  local t2 = t1:clone()
+  local t3 = torch.randn(100,100)
+
+  local success, msg = totem.areTensorsNe(t1, t3, 1e-5)
+  tester:assert(success, "areTensorsNe should return true")
+  tester:asserteq(msg, nil, "areTensorsNe erroneously gives msg on success")
+
+  local success, msg = totem.areTensorsNe(t1, t2, 1e-5)
+  tester:assert(not success, "areTensorsNe should return false")
+  tester:asserteq(type(msg), 'string', "areTensorsNe should return a message")
+
+  tester:assertNoError(function() totem.assertTensorNe(t1, t3, 1e-5) end,
+                       "assertTensorNe not raising an error")
+  tester:assertError(function() totem.assertTensorNe(t1, t2, 1e-5) end,
+                     "assertTensorNe not raising an error")
+end
+
 tester:add(tests):run()

--- a/totem/Tester.lua
+++ b/totem/Tester.lua
@@ -141,7 +141,7 @@ or equal to `condition`.
 
 ]]
 function Tester:assertTensorEq(ta, tb, condition, message)
-    local success, subMessage = totem.assertTensorEq(ta, tb, condition)
+    local success, subMessage = totem.areTensorsEq(ta, tb, condition)
     return self:_assert_sub(success, string.format("%s\n%s", message, subMessage))
 end
 
@@ -158,7 +158,7 @@ The tensors are considered unequal if the maximum pointwise difference >= condit
 
 ]]
 function Tester:assertTensorNe(ta, tb, condition, message)
-    local success, subMessage = totem.assertTensorNe(ta, tb, condition)
+    local success, subMessage = totem.areTensorsNe(ta, tb, condition)
     return self:_assert_sub(success, string.format("%s\n%s", message, subMessage))
 end
 

--- a/totem/asserts.lua
+++ b/totem/asserts.lua
@@ -13,14 +13,10 @@ Tests whether the maximum pointwise difference between `a` and `b` is less than
 or equal to `condition`.
 
 ]]
-function totem.areTensorsEq(ta, tb, condition, neg)
-  -- If neg is true, we invert success and failure
-  -- This allows to easily implement Tester:assertTensorNe
-  local invert = false
-  if neg == nil then
-    invert = false
-  else
-    invert = true
+function totem.areTensorsEq(ta, tb, condition, _negate)
+  -- If _negate is true, we invert success and failure
+  if _negate == nil then
+    _negate = false
   end
 
   if ta:dim() ~= tb:dim() then
@@ -48,14 +44,14 @@ function totem.areTensorsEq(ta, tb, condition, neg)
 
   local diff = ta:clone():add(-1, tb)
   local err = diff:abs():max()
-  local violation = invert and 'TensorNE(==)' or ' TensorEQ(==)'
+  local violation = _negate and 'TensorNE(==)' or ' TensorEQ(==)'
   local errMessage = string.format('%s violation: val=%s, condition=%s',
                                    violation,
                                    tostring(err),
                                    tostring(condition))
 
   local success = err <= condition
-  if invert then
+  if _negate then
     success = not success
   end
   return success, (not success) and errMessage or nil
@@ -85,6 +81,9 @@ Parameters:
 - `ta` (tensor)
 - `tb` (tensor)
 - `condition` (number)
+
+Returns two values:
+success (boolean), failure_message (string or nil)
 
 The tensors are considered unequal if the maximum pointwise difference >= condition.
 

--- a/totem/asserts.lua
+++ b/totem/asserts.lua
@@ -1,4 +1,4 @@
---[[ Assert tensor equality
+--[[ Test for tensor equality
 
 Parameters:
 
@@ -6,11 +6,14 @@ Parameters:
 - `tb` (tensor)
 - `condition` (number) maximum pointwise difference between `a` and `b`
 
-Asserts that the maximum pointwise difference between `a` and `b` is less than
+Returns two values:
+success (boolean), failure_message (string or nil)
+
+Tests whether the maximum pointwise difference between `a` and `b` is less than
 or equal to `condition`.
 
 ]]
-function totem.assertTensorEq(ta, tb, condition, neg)
+function totem.areTensorsEq(ta, tb, condition, neg)
     -- If neg is true, we invert success and failure
     -- This allows to easily implement Tester:assertTensorNe
     local invert = false
@@ -51,11 +54,43 @@ function totem.assertTensorEq(ta, tb, condition, neg)
                                      tostring(err),
                                      tostring(condition))
 
+    local success = err <= condition
     if invert then
-        return not (err <= condition), errMessage
-    else
-        return err <= condition , errMessage
+        success = not success
     end
+    return success, (not success) and errMessage or nil
+end
+
+--[[ Assert tensor equality
+
+Parameters:
+
+- `ta` (tensor)
+- `tb` (tensor)
+- `condition` (number) maximum pointwise difference between `a` and `b`
+
+Asserts that the maximum pointwise difference between `a` and `b` is less than
+or equal to `condition`.
+
+]]
+function totem.assertTensorEq(ta, tb, condition)
+  return assert(totem.areTensorsEq(ta, tb, condition))
+end
+
+
+--[[ Test for tensor inequality
+
+Parameters:
+
+- `ta` (tensor)
+- `tb` (tensor)
+- `condition` (number)
+
+The tensors are considered unequal if the maximum pointwise difference >= condition.
+
+]]
+function totem.areTensorsNe(ta, tb, condition)
+  return totem.areTensorsEq(ta, tb, condition, true)
 end
 
 --[[ Assert tensor inequality
@@ -70,7 +105,7 @@ The tensors are considered unequal if the maximum pointwise difference >= condit
 
 ]]
 function totem.assertTensorNe(ta, tb, condition)
-  return totem.assertTensorEq(ta, tb, condition, true)
+  assert(totem.areTensorsNe(ta, tb, condition))
 end
 
 


### PR DESCRIPTION
* Make `totem.assertTensorEq` perform an assertion. The original function is renamed to `totem.areTensorsEq`. 
* Add similar changes for `totem.assertTensorNe`.
* Add tests for the above.
* Fix indentation in totem/asserts.lua
