### PR TITLE
Allow differently typed tensors within modules

### DIFF
--- a/totem/nn.lua
+++ b/totem/nn.lua
@@ -345,9 +345,6 @@ function totem.nn.checkTypeCastable(tester, module, input, toType, precision)
                 table.insert(accOrig, curlevel)
             elseif obj_type == toType then
                 table.insert(accToType, curlevel)
-            else
-                -- I am not sure what the correct way to deal with objects that are tensors, but are neither of the original or the new type
-                tester:assert(false, 'found an object ' .. curlevel .. ' which is neither of from type or to type' )
             end
             return accOrig, accToType, visitedObj
         else


### PR DESCRIPTION
The new lua-only implementations of e.g. nn.Min and Max, and modules derived from these, have for instance LongTensor member variables (for indices). They then fail typecast checks.