### PR TITLE
Fixed the totem tester which would assert even with 'ret' = true

### DIFF
--- a/totem/nn.lua
+++ b/totem/nn.lua
@@ -3,7 +3,7 @@
 totem.nn = {}
 
 local function inputType(t)
-    return type(t) == 'table' and t[1]:type() or t:type()
+    return type(t) == 'table' and inputType(t[1]) or t:type()
 end
 
 


### PR DESCRIPTION
The problem was that the subfunctions called by Tester:eq were not taking into account the 'ret' value.
I also added a test which counts the number of asserts of the tester to make sure that it does not assert when it should not.