### PR TITLE
Fix :eq for tables with named entries

### DIFF
--- a/totem/Tester.lua
+++ b/totem/Tester.lua
@@ -365,8 +365,8 @@ function Tester:_eqTable(got, expected, label, precision)
         if type(value2) == 'table' then
             value2 = 'table2'
         end
-        self:_failure(string.format("%s inconsistent values: %s != %s at position %d",
-                      label, tostring(value1), tostring(value2), position))
+        self:_failure(string.format("%s inconsistent values: %s != %s at position %s",
+                      label, tostring(value1), tostring(value2), tostring(position)))
     end
 
     if #got ~= #expected then


### PR DESCRIPTION
Previously one would get a very uninformative error message when tables with named entries would differ:

 bad argument #5 to 'format' (number expected, got string)