### PR TITLE
More unified comparison for generic types, tables and torch types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,3 @@ Example:
 ```sh
 totem-run --folder tests --summary
 ```
-

--- a/examples/test_nn.lua
+++ b/examples/test_nn.lua
@@ -3,7 +3,7 @@
 require 'totem'
 require 'nn'
 
-test = {}
+local test = totem.TestSuite()
 
 local tester = totem.Tester()
 

--- a/examples/test_rethrow.lua
+++ b/examples/test_rethrow.lua
@@ -21,7 +21,7 @@ function test.B()
     local function f()
         return concatenate(a, b)
     end
-    -- assertError works similarly when using the command line parameter --rethrow 
+    -- assertError works similarly when using the command line parameter --rethrow
     tester:assertError(f, 'Error not caught')
 end
 
@@ -29,8 +29,8 @@ function test.C()
     local a = 'Hello'
     -- This assert will produce an error while trying to concatenate a nil value
     -- The command line parameter --rethrow makes the program crash with this
-    -- error with the correct information in the stack 
+    -- error with the correct information in the stack.
     tester:asserteq(concatenate(a,b), 'Hello World', 'Error in concatenation')
 end
-  
+
 return tester:add(test):run()

--- a/examples/test_simple.lua
+++ b/examples/test_simple.lua
@@ -2,24 +2,24 @@
 
 require 'totem'
 
-test = {}
+local test = totem.TestSuite()
 
-tester = totem.Tester()
+local tester = totem.Tester()
 
-function test.A()
+function test.a()
     local a = 10
     local b = 10
     tester:asserteq(a, b, 'a == b')
-    tester:assertne(a,b,'a ~= b')
+    tester:assertne(a, b, 'a ~= b')
 end
 
-function test.B()
+function test.b()
     local a = 10
     local b = 9
     tester:assertgt(a, b, 'a > b')
 end
 
-function test.C()
+function test.c()
     error('Errors are treated differently than failures')
 end
 

--- a/examples/test_storage.lua
+++ b/examples/test_storage.lua
@@ -1,0 +1,38 @@
+#!/usr/bin/env th
+
+require 'totem'
+
+local test = totem.TestSuite()
+
+local tester = totem.Tester()
+
+function test.size()
+    local a = torch.Storage(1)
+    local b = torch.Storage(2)
+    tester:assertStorageEq(a, b, 1e-16, 'a == b')
+    tester:assertStorageNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.type()
+    local a = torch.DoubleStorage({1, 2, 3})
+    local b = torch.IntStorage({1, 2, 3})
+    tester:assertStorageEq(a, b, 1e-16, 'a == b')
+    tester:assertStorageNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.differentValues()
+    local a = torch.Storage({1, 2})
+    local b = torch.Storage({3, 4})
+    tester:assertStorageEq(a, b, 1e-16, 'a == b')
+    tester:assertStorageNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.sameValues()
+    local a = torch.Storage({1, 2})
+    local b = torch.Storage({1, 2})
+    tester:assertStorageEq(a, b, 1e-16, 'a == b')
+    tester:assertStorageNe(a, b, 1e-16, 'a ~= b')
+end
+
+
+return tester:add(test):run()

--- a/examples/test_table.lua
+++ b/examples/test_table.lua
@@ -1,0 +1,58 @@
+#!/usr/bin/env th
+
+require 'totem'
+
+local test = totem.TestSuite()
+
+local tester = totem.Tester()
+
+function test.size()
+    local a = {1}
+    local b = {1, 2}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.sameValues()
+    local a = {1, 2, 3}
+    local b = {1, 2, 3}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.differentValues()
+    local a = {1, 3}
+    local b = {1, 2}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.sameValuesNested()
+    local a = {1, {1, 2}}
+    local b = {1, {1, 2}}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.differentValuesNested()
+    local a = {1, {1, 2}}
+    local b = {1, {1, 3}}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.sameValuesNestedWithOtherTypes()
+    local a = {1, {1, torch.DoubleTensor(2):zero()}}
+    local b = {1, {1, torch.DoubleTensor(2):zero()}}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.differentValuesNestedWithOtherTypes()
+    local a = {1, {1, torch.DoubleTensor(2):zero()}}
+    local b = {1, {1, torch.FloatTensor(2):zero()}}
+    tester:assertTableEq(a, b, 1e-16, 'a == b')
+    tester:assertTableNe(a, b, 1e-16, 'a ~= b')
+end
+
+return tester:add(test):run()

--- a/examples/test_tensor.lua
+++ b/examples/test_tensor.lua
@@ -2,34 +2,48 @@
 
 require 'totem'
 
-test = {}
+local test = totem.TestSuite()
 
 local tester = totem.Tester()
 
-function test.Dimension()
-    local a = torch.Tensor(1,2)
+function test.dimension()
+    local a = torch.Tensor(1, 2)
     local b = torch.Tensor(2)
     tester:assertTensorEq(a, b, 1e-16, 'a == b')
     tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
 end
 
-function test.Size()
-    local a = torch.Tensor(1,2)
-    local b = torch.Tensor(2,2)
+function test.size()
+    local a = torch.Tensor(1, 2)
+    local b = torch.Tensor(2, 2)
     tester:assertTensorEq(a, b, 1e-16, 'a == b')
     tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
 end
 
-function test.DifferentValues()
-    local a = torch.zeros(1,2)
-    local b = torch.ones(1,2)
+function test.tensorsOfDimZero()
+    local a = torch.Tensor()
+    local b = torch.Tensor()
     tester:assertTensorEq(a, b, 1e-16, 'a == b')
     tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
 end
 
-function test.SameValues()
-    local a = torch.zeros(1,2)
-    local b = torch.zeros(1,2)
+function test.type()
+    local a = torch.DoubleTensor(3):zero()
+    local b = torch.IntTensor(3):zero()
+    tester:assertTensorEq(a, b, 1e-16, 'a == b')
+    tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.differentValues()
+    local a = torch.zeros(1, 2)
+    local b = torch.ones(1, 2)
+    tester:assertTensorEq(a, b, 1e-16, 'a == b')
+    tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
+end
+
+function test.sameValues()
+    local a = torch.zeros(1, 2)
+    local b = torch.zeros(1, 2)
     tester:assertTensorEq(a, b, 1e-16, 'a == b')
     tester:assertTensorNe(a, b, 1e-16, 'a ~= b')
 end

--- a/rocks/totem-0-0.rockspec
+++ b/rocks/totem-0-0.rockspec
@@ -25,6 +25,8 @@ build = {
 		['totem.asserts'] = 'totem/asserts.lua',
 		['totem.examples.test_simple'] = 'examples/test_simple.lua',
 		['totem.examples.test_nn'] = 'examples/test_nn.lua',
+		['totem.examples.test_storage'] = 'examples/test_storage.lua',
+		['totem.examples.test_table'] = 'examples/test_table.lua',
 		['totem.examples.test_tensor'] = 'examples/test_tensor.lua',
 	},
 	install = {

--- a/tests/test_totem.lua
+++ b/tests/test_totem.lua
@@ -19,11 +19,11 @@ local calls_to_setUp = 0
 local calls_to_tearDown = 0
 
 local function meta_assert_success(success, message)
-  tester:assert(success==true, "assert wasn't successful")
+  tester:assert(success == true, "assert wasn't successful")
   tester:assert(string.find(message, MESSAGE) ~= nil, "message doesn't match")
 end
 local function meta_assert_failure(success, message)
-  tester:assert(success==false, "assert didn't fail")
+  tester:assert(success == false, "assert didn't fail")
   tester:assert(string.find(message, MESSAGE) ~= nil, "message doesn't match")
 end
 
@@ -49,42 +49,48 @@ function tests.test_assertTensorEq_alltypes()
       torch.FloatTensor,
       torch.DoubleTensor,
   }
-  for _, tensor in ipairs(allTypes) do
-    local t1 = tensor():ones(10)
-    local t2 = tensor():ones(10)
-    meta_assert_success(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
+  for _, tensor1 in ipairs(allTypes) do
+    for _, tensor2 in ipairs(allTypes) do
+      local t1 = tensor1():ones(10)
+      local t2 = tensor2():ones(10)
+      if tensor1 == tensor2 then
+        meta_assert_success(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
+      else
+        meta_assert_failure(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
+      end
+    end
   end
 end
 
 function tests.test_assertTensorSizes()
   local t1 = torch.ones(2)
   local t2 = torch.ones(3)
-  local t3 = torch.ones(1,2)
+  local t3 = torch.ones(1, 2)
   meta_assert_failure(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
-  meta_assert_failure(subtester:assertTensorNe(t1, t2, 1e-6, MESSAGE))
+  meta_assert_success(subtester:assertTensorNe(t1, t2, 1e-6, MESSAGE))
   meta_assert_failure(subtester:assertTensorEq(t1, t3, 1e-6, MESSAGE))
-  meta_assert_failure(subtester:assertTensorNe(t1, t3, 1e-6, MESSAGE))
+  meta_assert_success(subtester:assertTensorNe(t1, t3, 1e-6, MESSAGE))
 end
 
 function tests.test_assertTensorEq()
-  local t1 = torch.randn(100,100)
+  local t1 = torch.randn(100, 100)
   local t2 = t1:clone()
-  local t3 = torch.randn(100,100)
+  local t3 = torch.randn(100, 100)
   meta_assert_success(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
   meta_assert_failure(subtester:assertTensorEq(t1, t3, 1e-6, MESSAGE))
 end
 
 function tests.test_assertTensorNe()
-  local t1 = torch.randn(100,100)
+  local t1 = torch.randn(100, 100)
   local t2 = t1:clone()
-  local t3 = torch.randn(100,100)
+  local t3 = torch.randn(100, 100)
   meta_assert_success(subtester:assertTensorNe(t1, t3, 1e-6, MESSAGE))
   meta_assert_failure(subtester:assertTensorNe(t1, t2, 1e-6, MESSAGE))
   end
 
 function tests.test_assertTensor_epsilon()
-  local t1 = torch.rand(100,100)
-  local t2 = torch.rand(100,100)*1e-5
+  local t1 = torch.rand(100, 100)
+  local t2 = torch.rand(100, 100) * 1e-5
   local t3 = t1 + t2
   meta_assert_success(subtester:assertTensorEq(t1, t3, 1e-4, MESSAGE))
   meta_assert_failure(subtester:assertTensorEq(t1, t3, 1e-6, MESSAGE))
@@ -92,13 +98,64 @@ function tests.test_assertTensor_epsilon()
   meta_assert_failure(subtester:assertTensorNe(t1, t3, 1e-4, MESSAGE))
 end
 
+function tests.test_assertStorageEq_alltypes()
+  local allTypes = {
+      torch.ByteStorage,
+      torch.CharStorage,
+      torch.ShortStorage,
+      torch.IntStorage,
+      torch.LongStorage,
+      torch.FloatStorage,
+      torch.DoubleStorage,
+  }
+  for _, storage1 in ipairs(allTypes) do
+    for _, storage2 in ipairs(allTypes) do
+      local s1 = storage1({1, 2, 3, 4})
+      local s2 = storage2({1, 2, 3, 4})
+      if storage1 == storage2 then
+        meta_assert_success(subtester:assertStorageEq(s1, s2, 1e-6, MESSAGE))
+      else
+        meta_assert_failure(subtester:assertStorageEq(s1, s2, 1e-6, MESSAGE))
+      end
+    end
+  end
+end
+
+function tests.test_assertStorageSizes()
+  local t1 = torch.ones(2)
+  local t2 = torch.ones(3)
+  meta_assert_failure(subtester:assertTensorEq(t1, t2, 1e-6, MESSAGE))
+end
+
+function tests.test_assertStorageEq()
+  local t1 = torch.randn(100, 100)
+  local t2 = t1:clone()
+  local t3 = torch.randn(100, 100)
+  local s1 = t1:storage()
+  local s2 = t2:storage()
+  local s3 = t3:storage()
+  meta_assert_success(subtester:assertStorageEq(s1, s2, 1e-6, MESSAGE))
+  meta_assert_failure(subtester:assertStorageEq(s1, s3, 1e-6, MESSAGE))
+end
+
+function tests.test_assertStorageNe()
+  local t1 = torch.randn(100, 100)
+  local t2 = t1:clone()
+  local t3 = torch.randn(100, 100)
+  local s1 = t1:storage()
+  local s2 = t2:storage()
+  local s3 = t3:storage()
+  meta_assert_success(subtester:assertStorageNe(s1, s3, 1e-6, MESSAGE))
+  meta_assert_failure(subtester:assertStorageNe(s1, s2, 1e-6, MESSAGE))
+end
+
 function tests.test_assertTable()
-  local tensor = torch.rand(100,100)
+  local tensor = torch.rand(100, 100)
   local t1 = {1, "a", key = "value", tensor = tensor, subtable = {"nested"}}
   local t2 = {1, "a", key = "value", tensor = tensor, subtable = {"nested"}}
   meta_assert_success(subtester:assertTableEq(t1, t2, MESSAGE))
   meta_assert_failure(subtester:assertTableNe(t1, t2, MESSAGE))
-  for k,v in pairs(t1) do
+  for k, v in pairs(t1) do
     local x = "something else"
     t2[k] = nil
     t2[x] = v
@@ -112,6 +169,36 @@ function tests.test_assertTable()
     meta_assert_success(subtester:assertTableEq(t1, t2, MESSAGE))
     meta_assert_failure(subtester:assertTableNe(t1, t2, MESSAGE))
   end
+end
+
+
+function tests.test_genericEq()
+  local tensor = torch.rand(100, 100)
+  local sameTensor = tensor:clone()
+  local t1 = {1, "a", key = "value", tensor = tensor, subtable = {"nested"}}
+  local t2 = {1, "a", key = "value", tensor = sameTensor, subtable = {"nested"}}
+  meta_assert_success(subtester:eq(t1, t2, MESSAGE, 1e-6))
+  meta_assert_failure(subtester:ne(t1, t2, MESSAGE, 1e-6))
+  for k, v in pairs(t1) do
+    local x = "something else"
+    t2[k] = nil
+    t2[x] = v
+    meta_assert_success(subtester:ne(t1, t2, MESSAGE, 1e-6))
+    meta_assert_failure(subtester:eq(t1, t2, MESSAGE, 1e-6))
+    t2[x] = nil
+    t2[k] = x
+    meta_assert_success(subtester:ne(t1, t2, MESSAGE, 1e-6))
+    meta_assert_failure(subtester:eq(t1, t2, MESSAGE, 1e-6))
+    t2[k] = v
+    meta_assert_success(subtester:eq(t1, t2, MESSAGE, 1e-6))
+    meta_assert_failure(subtester:ne(t1, t2, MESSAGE, 1e-6))
+  end
+  meta_assert_success(subtester:eq(3, 3, MESSAGE, 1e-6))
+  meta_assert_failure(subtester:ne(3, 3, MESSAGE, 1e-6))
+  meta_assert_success(subtester:ne(3, "3", MESSAGE, 1e-6))
+  meta_assert_failure(subtester:eq(3, "3", MESSAGE, 1e-6))
+  meta_assert_success(subtester:eq("3", "3", MESSAGE, 1e-6))
+  meta_assert_failure(subtester:ne("3", "3", MESSAGE, 1e-6))
 end
 
 --[[ Returns a Tester with `numSuccess` success cases, `numFailure` failure
@@ -221,6 +308,25 @@ function tests.test_assertErrorPattern()
   meta_assert_failure(subtester:assertErrorPattern(bad_fn, "hehe", MESSAGE))
 end
 
+function tests.test_TensorEqChecksEmpty()
+  local t1 = torch.DoubleTensor()
+  local t2 = t1:clone()
+  local t3 = torch.randn(100,100)
+
+  local success, msg = totem.areTensorsEq(t1, t2, 1e-5)
+  tester:assert(success, "areTensorsEq should return true")
+
+  local success, msg = totem.areTensorsEq(t1, t3, 1e-5)
+  tester:assert(not success, "areTensorsEq should return false")
+  tester:assertErrorPattern(function() totem.assertTensorEq(t1, t3, 1e-5) end,
+                     "different dimensions",
+                     "wrong error message for tensors of different dimensions")
+
+  tester:assertNoError(function() totem.assertTensorEq(t1, t2, 1e-5) end,
+                       "assertTensorEq not raising an error")
+
+end
+
 function tests.test_TensorEqChecks()
   local t1 = torch.randn(100,100)
   local t2 = t1:clone()
@@ -228,7 +334,6 @@ function tests.test_TensorEqChecks()
 
   local success, msg = totem.areTensorsEq(t1, t2, 1e-5)
   tester:assert(success, "areTensorsEq should return true")
-  tester:asserteq(msg, nil, "areTensorsEq erroneously gives msg on success")
 
   local success, msg = totem.areTensorsEq(t1, t3, 1e-5)
   tester:assert(not success, "areTensorsEq should return false")
@@ -241,13 +346,12 @@ function tests.test_TensorEqChecks()
 end
 
 function tests.test_TensorNeChecks()
-  local t1 = torch.randn(100,100)
+  local t1 = torch.randn(100, 100)
   local t2 = t1:clone()
-  local t3 = torch.randn(100,100)
+  local t3 = torch.randn(100, 100)
 
   local success, msg = totem.areTensorsNe(t1, t3, 1e-5)
   tester:assert(success, "areTensorsNe should return true")
-  tester:asserteq(msg, nil, "areTensorsNe erroneously gives msg on success")
 
   local success, msg = totem.areTensorsNe(t1, t2, 1e-5)
   tester:assert(not success, "areTensorsNe should return false")
@@ -330,7 +434,11 @@ function tests.test_checkTypePreservesSharing()
       totem.nn.checkTypePreservesSharing(dummyTest, seq, 'torch.FloatTensor')
   end
   dummyTest:add(test)
-  local testSuccess, msg = pcall(dummyTest.run, dummyTest)
+  -- change io.write behavior to not output sub-tests
+  local oldWrite = io.write
+  io.write = function() end
+  local testSuccess = pcall(function() return dummyTest:run() end)
+  io.write = oldWrite
   tester:asserteq(testSuccess, false, 'expect test failure, mod breaks sharing')
 end
 

--- a/totem/asserts.lua
+++ b/totem/asserts.lua
@@ -1,27 +1,80 @@
--- Functions for checking Tensor and Table equality.
+-- Functions for checking Tensor, Storage and Table equality.
 
---[[ Test for tensor equality
+--[[ Tests for tensor equality between two tensors of matching sizes and types
 
-Tests whether the maximum element-wise difference between `a` and `b` is less
+Tests whether the maximum element-wise difference between `ta` and `tb` is less
 than or equal to `tolerance`.
 
 Arguments:
 
 * `ta` (tensor)
 * `tb` (tensor)
-* `tolerance` (optional, number) maximum elementwise difference between `a`
-     and `b`. Defaults to `0`.
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `ta` and `tb`.
+* `negate` (optional boolean, default false) if `negate` is true, we invert
+    success and failure.
+* `storage` (optional boolean, default false) if `storage` is true, we print an
+    error message referring to Storages rather than Tensors.
 
 Returns:
 
 1. success, boolean that indicates success
 2. failure_message, string or nil
 ]]
-function totem.areTensorsEq(ta, tb, tolerance, _negate)
-  -- If _negate is true, we invert success and failure
-  if _negate == nil then
-    _negate = false
+local function areSameFormatTensorsEq(ta, tb, tolerance, negate, storage)
+
+  local function ensureHasAbs(t)
+    -- Byte, Char and Short Tensors don't have abs
+    return t.abs and t or t:double()
   end
+
+  ta = ensureHasAbs(ta)
+  tb = ensureHasAbs(tb)
+
+  local diff = ta:clone():add(-1, tb):abs()
+  local err = diff:max()
+  local success = err <= tolerance
+  if negate then
+    success = not success
+  end
+
+  local errMessage
+  if not success then
+    local prefix = storage and 'Storage' or 'Tensor'
+    local violation = negate and 'NE(==)' or 'EQ(==)'
+    errMessage = string.format('%s%s violation: max diff=%s, tolerance=%s',
+                               prefix,
+                               violation,
+                               tostring(err),
+                               tostring(tolerance))
+  end
+
+  return success, errMessage
+end
+
+
+--[[ Tests for tensor equality
+
+Tests whether the maximum element-wise difference between `ta` and `tb` is less
+than or equal to `tolerance`. Throws an error if one of its two first arguments
+is not a tensor.
+
+Arguments:
+
+* `ta` (tensor)
+* `tb` (tensor)
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `ta` and `tb`.
+* `negate` (optional boolean, default false) if negate is true, we invert
+    success and failure.
+
+Returns:
+
+1. success, boolean that indicates success
+2. failure_message, string or nil
+]]
+function totem.areTensorsEq(ta, tb, tolerance, negate)
+  negate = negate or false
   tolerance = tolerance or 0
   assert(torch.isTensor(ta), "First argument should be a Tensor")
   assert(torch.isTensor(tb), "Second argument should be a Tensor")
@@ -30,137 +83,354 @@ function totem.areTensorsEq(ta, tb, tolerance, _negate)
          .. " equality for a single element")
 
   if ta:dim() ~= tb:dim() then
-    return false, 'The tensors have different dimensions'
-  end
-  local sizea = torch.DoubleTensor(ta:size():totable())
-  local sizeb = torch.DoubleTensor(tb:size():totable())
-  local sizediff = sizea:clone():add(-1, sizeb)
-  local sizeerr = sizediff:abs():max()
-  if sizeerr ~= 0 then
-    return false, 'The tensors have different sizes'
+    return negate, 'The tensors have different dimensions'
   end
 
-  local function ensureHasAbs(t)
-  -- Byte, Char and Short Tensors don't have abs
-    if not t.abs then
-      return t:double()
-    else
-      return t
-    end
+  if ta:type() ~= tb:type() then
+    return negate, 'The tensors have different types'
   end
 
-  ta = ensureHasAbs(ta)
-  tb = ensureHasAbs(tb)
-
-  local diff = ta:clone():add(-1, tb)
-  local err = diff:abs():max()
-  local violation = _negate and 'TensorNE(==)' or ' TensorEQ(==)'
-  local errMessage = string.format('%s violation: val=%s, tolerance=%s',
-                                   violation,
-                                   tostring(err),
-                                   tostring(tolerance))
-
-  local success = err <= tolerance
-  if _negate then
-    success = not success
+  -- If we are comparing two empty tensors, return true.
+  -- This is needed because some functions below cannot be applied to tensors
+  -- of dimension 0.
+  if ta:dim() == 0 then
+    return not negate, 'Both tensors are empty'
   end
-  return success, (not success) and errMessage or nil
+
+  if not ta:isSameSizeAs(tb) then
+    return negate, 'Both tensors are empty'
+  end
+
+  return areSameFormatTensorsEq(ta, tb, tolerance, negate, false)
+
 end
+
 
 --[[ Asserts tensor equality.
 
-Asserts that the maximum elementwise difference between `a` and `b` is less than
-or equal to `tolerance`.
+Asserts that the maximum elementwise difference between `ta` and `tb` is less
+than or equal to `tolerance`. Fails if one of its two first arguments is not a
+tensor.
 
 Arguments:
 
 * `ta` (tensor)
 * `tb` (tensor)
-* `tolerance` (optional, number) maximum elementwise difference between `a` and
-    `b`. Defaults to `0`.
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `a` and `b`.
 ]]
 function totem.assertTensorEq(ta, tb, tolerance)
   return assert(totem.areTensorsEq(ta, tb, tolerance))
 end
 
 
---[[ Test for tensor inequality
+--[[ Tests for tensor inequality
 
-The tensors are considered unequal if the maximum elementwise difference >=
-`tolerance`.
+The tensors are considered unequal if the maximum elementwise difference >
+`tolerance`. Throws an error if one of its two first arguments is not a tensor.
 
 Arguments:
 
 * `ta` (tensor)
 * `tb` (tensor)
-* `tolerance` (optional, number). Defaults to `0`.
+* `tolerance` (optional number, default 0).
 
 Returns:
 1. success, a boolean indicating success
 2. failure_message, string or nil
-
 ]]
 function totem.areTensorsNe(ta, tb, tolerance)
   return totem.areTensorsEq(ta, tb, tolerance, true)
 end
 
+
 --[[ Asserts tensor inequality.
 
-The tensors are considered unequal if the maximum elementwise difference >=
-`tolerance`.
+The tensors are considered unequal if the maximum elementwise difference >
+`tolerance`. Fails if one of its two first arguments is not a tensor.
 
 Arguments:
 
 * `ta` (tensor)
 * `tb` (tensor)
-* `tolerance` (optional, number). Defaults to `0`.
+* `tolerance` (optional number, default 0).
 ]]
 function totem.assertTensorNe(ta, tb, tolerance)
-  assert(totem.areTensorsNe(ta, tb, tolerance))
+  return assert(totem.areTensorsNe(ta, tb, tolerance))
 end
 
-local function isIncludedIn(ta, tb)
-  if type(ta) ~= 'table' or type(tb) ~= 'table' then
-    return ta == tb, '--> (Table 1) value: '.. tostring(ta) ..
-                     ', (Table 2) value: ' .. tostring(tb)
-  end
-  for k, v in pairs(tb) do
-    local equal, errMsg = totem.assertTableEq(ta[k], v)
-    if not equal then return false, '['.. k .. ']' .. errMsg end
-  end
-  return true, nil
-end
 
---[[ Asserts that two tables are equal (comparing values, recursively).
+local typesMatching = {
+    ['torch.ByteStorage'] = torch.ByteTensor,
+    ['torch.CharStorage'] = torch.CharTensor,
+    ['torch.ShortStorage'] = torch.ShortTensor,
+    ['torch.IntStorage'] = torch.IntTensor,
+    ['torch.LongStorage'] = torch.LongTensor,
+    ['torch.FloatStorage'] = torch.FloatTensor,
+    ['torch.DoubleStorage'] = torch.DoubleTensor,
+}
+
+
+--[[ Tests for storage equality
+
+Tests whether the maximum element-wise difference between `sa` and `sb` is less
+than or equal to `tolerance`. Throws an error if one of its two first arguments
+is not a storage.
 
 Arguments:
 
-* `actual` (table)
-* `expected` (table)
+* `sa` (storage)
+* `sb` (storage)
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `a` and `b`.
+* `negate` (optional boolean, default false) if negate is true, we invert
+    success and failure.
 
 Returns:
-1. success, a boolean indicating equality
-2. failure_message, string or nil (if not equal) where string starts with
-   the hierarchical location (e.g. [ind1][ind2]) of the first difference
-   between the two tables followed by the values in those locations for
-   both tables.
+
+1. success, boolean that indicates success
+2. failure_message, string or nil
 ]]
-function totem.assertTableEq(ta, tb)
-    local bIncAB, mesAB = isIncludedIn(ta, tb)
-    if not bIncAB then return bIncAB, mesAB end
-    local bIncBA, mesBA = isIncludedIn(tb, ta)
-    if not bIncBA then return bIncBA, mesBA end
-    return true, nil
+function totem.areStoragesEq(sa, sb, tolerance, negate)
+  -- If negate is true, we invert success and failure
+  negate = negate or false
+  tolerance = tolerance or 0
+  assert(torch.isStorage(sa), "First argument should be a Storage")
+  assert(torch.isStorage(sb), "Second argument should be a Storage")
+  assert(type(tolerance) == 'number',
+         "Third argument should be a number describing a tolerance on"
+         .. " equality for a single element")
+
+  if sa:size() ~= sb:size() then
+    return negate, 'The storages have different sizes'
+  end
+
+  local typeOfsa = torch.type(sa)
+  local typeOfsb = torch.type(sb)
+
+  if typeOfsa ~= typeOfsb then
+    return negate, 'The storages have different types'
+  end
+
+  local ta = typesMatching[typeOfsa](sa)
+  local tb = typesMatching[typeOfsb](sb)
+
+  return areSameFormatTensorsEq(ta, tb, tolerance, negate, true)
 end
 
---[[ Asserts that two tables are *not* equal (comparing values, recursively).
+
+--[[ Asserts storage equality.
+
+Asserts that the maximum elementwise difference between `sa` and `sb` is less
+than or equal to `tolerance`. Fails if one of its two first arguments is not a
+storage.
 
 Arguments:
 
-* `actual` (table)
-* `expected` (table)
-
+* `sa` (storage)
+* `sb` (storage)
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `a` and `b`.
 ]]
-function totem.assertTableNe(ta, tb)
-    return not totem.assertTableEq(ta, tb)
+function totem.assertStorageEq(sa, sb, tolerance)
+  return assert(totem.areStoragesEq(sa, sb, tolerance))
+end
+
+
+--[[ Tests for storage inequality
+
+The storages are considered unequal if the maximum elementwise difference >
+`tolerance`. Throws an error if one of its two first arguments is not a storage.
+
+Arguments:
+
+* `sa` (storage)
+* `sb` (storage)
+* `tolerance` (optional number, default 0).
+
+Returns:
+1. success, a boolean indicating success
+2. failure_message, string or nil
+]]
+function totem.areStoragesNe(sa, sb, tolerance)
+  return totem.areStoragesEq(sa, sb, tolerance, true)
+end
+
+
+--[[ Asserts storage inequality.
+
+The storages are considered unequal if the maximum elementwise difference >
+`tolerance`. Fails if one of its two first arguments is not a storage.
+
+Arguments:
+
+* `sa` (storage)
+* `sb` (storage)
+* `tolerance` (optional number, default 0).
+]]
+function totem.assertStorageNe(sa, sb, tolerance)
+  return assert(totem.areStoragesNe(sa, sb, tolerance))
+end
+
+
+--[[ Tests for general (deep) equality
+
+The types of `got` and `expected` must match.
+Tables are compared recursively. Keys and types of the associated values must
+match, recursively. Numbers are compared with the given tolerance.
+Torch tensors and storages are compared with the given tolerance on their
+elementwise difference. Other types are compared for strict equality with the
+regular Lua == operator.
+
+Arguments:
+
+* `got`
+* `expected`
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `a` and `b`.
+* `negate` (optional boolean, default false) if negate is true, we invert
+    success and failure.
+
+Returns:
+
+1. success, boolean that indicates success
+2. failure_message, string or nil
+]]
+function totem.areEq(got, expected, tolerance, negate)
+    negate = negate or false
+    tolerance = tolerance or 0
+    local errMessage
+    local violation = negate and 'NE(==)' or 'EQ(==)'
+    if type(got) ~= type(expected) then
+      if not negate then
+        errMessage = 'Arguments are not of the same type (got: ' .. type(got) ..
+            ', expected: ' .. type(expected) .. ')'
+      end
+      return negate, errMessage
+    elseif type(got) == 'number' then
+        local diff = math.abs(got - expected)
+        local ok = (diff <= tolerance)
+        if negate then
+          ok = not ok
+        end
+        if not ok then
+          errMessage = string.format('%s%s violation: max diff=%s,' ..
+                                      ' tolerance=%s',
+                                      type(got),
+                                      violation,
+                                      tostring(diff),
+                                      tostring(tolerance))
+        end
+        return ok, errMessage
+    elseif type(expected) == "table" then
+      return totem.areTablesEq(got, expected, tolerance, negate)
+    elseif torch.isTensor(got) then
+      return totem.areTensorsEq(got, expected, tolerance, negate)
+    elseif torch.isStorage(got) then
+      return totem.areStoragesEq(got, expected, tolerance, negate)
+    else
+    -- Below: we have the same type which is either userdata or a lua type
+    -- which is not a number.
+      local ok = (got == expected)
+      if negate then
+        ok = not ok
+      end
+      if not ok then
+        errMessage = string.format('%s%s violation: val1=%s, val2=%s',
+                          type(got),
+                          violation,
+                          tostring(got),
+                          tostring(expected))
+      end
+      return ok, errMessage
+    end
+end
+
+
+--[[ Tests for (deep) table equality
+
+Tables are compared recursively. Keys and types of the associated values must
+match, recursively. Numbers are compared with the given tolerance.
+Torch tensors and storages are compared with the given tolerance on their
+elementwise difference. Other types are compared for strict equality with the
+regular Lua == operator. Throws an error if one of its two first arguments is
+not a table.
+
+Arguments:
+
+* `t1` (table)
+* `t2` (table)
+* `tolerance` (optional number, default 0) maximum elementwise difference
+    between `a` and `b`.
+* `negate` (optional boolean, default false) if negate is true, we invert
+    success and failure.
+
+Returns:
+
+1. success, boolean that indicates success
+2. failure_message, string or nil
+]]
+function totem.areTablesEq(t1, t2, tolerance, negate)
+  negate = negate or false
+  tolerance = tolerance or 0
+  assert(type(t1) == 'table', "First argument should be a Table")
+  assert(type(t2) == 'table', "Second argument should be a Table")
+  assert(type(tolerance) == 'number',
+         "Third argument should be a number describing a tolerance on"
+         .. " equality for a single element")
+
+  for k, v in pairs(t2) do
+    local ok, message = totem.areEq(t1[k], v, tolerance, false)
+      if not ok then
+        return negate, message
+      end
+  end
+
+  for k, v in pairs(t1) do
+    local ok, message = totem.areEq(v, t2[k], tolerance, false)
+      if not ok then
+        return negate, message
+      end
+  end
+
+  return not negate, 'The tables are equal.'
+end
+
+
+--[[ Asserts (deep) table equality.
+
+Tables are compared recursively. Keys and types of the associated values must
+match, recursively. Numbers are compared with the given tolerance.
+Torch tensors and storages are compared with the given tolerance on their
+elementwise difference. Other types are compared for strict equality with the
+regular Lua == operator. Fails if one of its two first arguments is not a table.
+
+Arguments:
+
+* `ta` (table)
+* `tb` (table)
+* `tolerance` (optional number, default 0).
+]]
+function totem.assertTableEq(ta, tb, tolerance)
+  return assert(totem.areTablesEq(ta, tb, tolerance))
+end
+
+
+--[[ Asserts (deep) table inequality.
+
+Tables are compared recursively. If any of their key or associated value type
+doesn't match, they are considered unequal. Otherwise, numbers are compared with
+the given tolerance. Torch tensors and storages are compared with the given
+tolerance on their elementwise difference. Other types are compared for strict
+equality with the regular Lua == operator. Fails if one of its two first
+arguments is not a table.
+
+Arguments:
+
+* `ta` (table)
+* `tb` (table)
+* `tolerance` (optional number, default 0).
+]]
+function totem.assertTableNe(ta, tb, tolerance)
+  return assert(totem.areTablesEq(ta, tb, tolerance, true))
 end

--- a/totem/nn.lua
+++ b/totem/nn.lua
@@ -482,6 +482,7 @@ function totem.nn.checkTypeCastable(tester, module, input, toType, precision)
     local preOutput = module:updateOutput(input)
     local gradOutput = produceRandomGradOutput(preOutput)
     local preGradInput = module:updateGradInput(input, gradOutput)
+
     tester:assertNoError(function() module:type(toType) end, "module cannot be cast to " .. toType)
 
     -- check that all components of the tensor have been correctly cast
@@ -495,8 +496,9 @@ function totem.nn.checkTypeCastable(tester, module, input, toType, precision)
     local castOutput = module:forward(castInput)
     local castGradOutput = castTableOfTensors(gradOutput, toType)
     local castGradInput = module:updateGradInput(castInput, castGradOutput)
-    tester:eq( preOutput, castTableOfTensors(castOutput, origType), "cast module output differs from before casting", precision)
-    tester:eq( preGradInput, castTableOfTensors(castGradInput, origType), "cast module grad input differs from before casting", precision)
+
+    tester:eq(castTableOfTensors(preOutput, toType), castOutput, "cast module output differs from before casting", precision)
+    tester:eq(castTableOfTensors(preGradInput, toType), castGradInput, "cast module grad input differs from before casting", precision)
 
     -- cast module back to original type
     tester:assertNoError(function() module:type(origType) end, "module cannot be base back to " .. origType)
@@ -505,8 +507,8 @@ function totem.nn.checkTypeCastable(tester, module, input, toType, precision)
     castTableOfTensors(gradOutput, origType)
     local postOutput = module:updateOutput(input)
     local postGradInput = module:updateGradInput(input, gradOutput)
-    tester:eq(preOutput, postOutput, "module output differs before and after typecast", precision)
-    tester:eq(preGradInput, postGradInput, "module gradInput differs before and after typecast", precision)
+    tester:eq(castTableOfTensors(preOutput, origType), postOutput, "module output differs before and after typecast", precision)
+    tester:eq(castTableOfTensors(preGradInput, origType), postGradInput, "module gradInput differs before and after typecast", precision)
 end
 
 


### PR DESCRIPTION
Generic comparison is done by ensuring that the types of the two objects match and then applying the following rules. Table comparison is done element-wise (keys and types of the associated values must match and are then compared recursively). Torch tensors and storages are compared element-wise. Other types are compared with the regular Lua == operator (Lua numbers can be compared with a certain tolerance). Type-specific access to each comparison are also provided.

Changes implied for the user: table comparison is more generic (it used to check for strict identity between tables), generic comparison and tensors comparison is more specific ;comparing tensors of non-matching types used to lead to erratic behavior -- either program crash (comparing float with doubles with the specific tensor comparison) or silent casting (comparing doubles with bytes or using the generic equality comparison) -- the behavior is now that any type mismatched lead to the failure of the equality test. It is the user responsibility to do any casting before comparing the objects.

Changes implied in the code: added storage comparison, re-factorized a bit the tensor comparison, modified the table comparison, re-factorized a bit the general equality comparison. Some code cleaning here and there. Some added tests and examples. Removed some tests that ensured that no error-message was returned on success.